### PR TITLE
  - Added "Tmux Integration" to the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,52 @@ And the plugin will display a virtual text next to it showing something like:
 #reminder 2024-08-25T14:00:00Z: Follow up on the meeting notes : in 2 hours
 ```
 
+## Tmux Integration
+
+The plugin includes a shell script that counts due reminders for display in your
+tmux status bar. When reminders are due, you'll see a notification in your tmux
+status line - a gentle nudge to run `:ReminderScan`.
+
+### Quick Setup
+
+Run `:ReminderTmuxSetup` in Neovim to get a copy-paste ready configuration
+snippet with the correct paths for your setup.
+
+### Manual Setup
+
+The script is located at `scripts/tmux-reminders.sh` in the plugin directory.
+It requires paths as arguments:
+
+```bash
+/path/to/nvim-reminders/scripts/tmux-reminders.sh ~/notes ~/zet
+```
+
+Add to your `tmux.conf`:
+
+```tmux
+set -g status-right '#(/path/to/nvim-reminders/scripts/tmux-reminders.sh ~/notes) %H:%M'
+```
+
+### Advanced Styling (Powerline)
+
+For a more polished look with powerline-style glyphs and the Nightfox color
+scheme:
+
+```tmux
+set -g status-right "#[fg=#131a24,bg=#131a24,nobold,nounderscore,noitalics]#[fg=#719cd6,bg=#131a24] #{prefix_highlight} #(/path/to/nvim-reminders/scripts/tmux-reminders.sh ~/notes ~/zet)#[fg=#aeafb0,bg=#131a24,nobold,nounderscore,noitalics]#[fg=#131a24,bg=#aeafb0] %Y-%m-%d  %I:%M %p #[fg=#719cd6,bg=#aeafb0,nobold,nounderscore,noitalics]#[fg=#131a24,bg=#719cd6,bold] #h "
+```
+
+The script outputs nothing when no reminders are due, and shows a red
+highlighted count when reminders need attention:
+
+```
+ 2 reminders
+```
+
+### Platform Support
+
+The script supports both macOS and Linux date parsing.
+
 ## Unit Tests and CI
 
 test locally by running editor command:

--- a/doc/nvim-reminders.txt
+++ b/doc/nvim-reminders.txt
@@ -7,6 +7,7 @@ Introduction.............................................|nvim-reminders-intro|
 Commands.................................................|nvim-reminders-commands|
 Reminders................................................|nvim-reminders-list|
 Configuration............................................|nvim-reminders-config|
+Tmux Integration.........................................|nvim-reminders-tmux|
 
 ==============================================================================
 INTRODUCTION                                            *nvim-reminders-intro*
@@ -22,6 +23,7 @@ COMMANDS                                                *nvim-reminders-commands
 :ReminderScan             Scan for due reminders
 :ReminderScanUpcoming     Scan for upcoming reminders within the next 7 days
 :ReminderScanAll          Scan for all reminders, both past and future
+:ReminderTmuxSetup        Show tmux integration setup instructions
 
 ==============================================================================
 REMINDERS                                               *nvim-reminders-list*
@@ -61,6 +63,46 @@ processing the `ReminderScan` and `ReminderScanUpcoming` commands.  Note,
     recursive_scan = true
   })
 
+==============================================================================
+TMUX INTEGRATION                                        *nvim-reminders-tmux*
+
+The plugin includes a shell script for tmux status bar integration. When
+reminders are due, you'll see a notification in your tmux status line.
+
+Quick Setup ~
+
+Run `:ReminderTmuxSetup` to get a copy-paste ready configuration snippet
+with the correct script path and your configured reminder paths.
+
+Manual Setup ~
+
+The script is located at `scripts/tmux-reminders.sh` in the plugin directory.
+It requires paths as arguments:
+>
+  /path/to/nvim-reminders/scripts/tmux-reminders.sh ~/notes ~/zet
+
+Add to your tmux.conf:
+>
+  set -g status-right '#(/path/to/script/tmux-reminders.sh ~/notes) %H:%M'
+
+Advanced Styling ~
+
+For powerline-style glyphs with the Nightfox color scheme:
+>
+  set -g status-right "#[fg=#131a24,bg=#131a24]#[fg=#719cd6,bg=#131a24] \
+    #{prefix_highlight} \
+    #(/path/to/tmux-reminders.sh ~/notes ~/zet)\
+    #[fg=#aeafb0,bg=#131a24]#[fg=#131a24,bg=#aeafb0] %Y-%m-%d %I:%M %p \
+    #[fg=#719cd6,bg=#aeafb0]#[fg=#131a24,bg=#719cd6,bold] #h "
+
+The script outputs nothing when no reminders are due. When reminders need
+attention, it displays a red highlighted count like:
+>
+   2 reminders
+
+Platform Support ~
+
+The script supports both macOS and Linux date parsing automatically.
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/scripts/tmux-reminders.sh
+++ b/scripts/tmux-reminders.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# tmux-reminders - Scan markdown files for due reminders
+# Outputs formatted string for tmux status-right
+#
+# Usage: tmux-reminders.sh <path1> [path2] [path3] ...
+#
+# Example in tmux.conf:
+#   set -g status-right '#(/path/to/tmux-reminders.sh ~/notes ~/zet)'
+#
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: tmux-reminders.sh <path1> [path2] ..." >&2
+    exit 1
+fi
+
+# Get current time as Unix timestamp
+now=$(date +%s)
+
+count=0
+
+for dir in "$@"; do
+    # Expand ~ to home directory
+    dir="${dir/#\~/$HOME}"
+
+    [[ -d "$dir" ]] || continue
+
+    # Scan only top-level .md files (no recursion)
+    for file in "$dir"/*.md; do
+        [[ -f "$file" ]] || continue
+
+        # Find unchecked reminders with ISO 8601 timestamps
+        while IFS= read -r line; do
+            # Extract the timestamp (format: 2025-08-13T15:51:15Z)
+            ts=$(echo "$line" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z')
+            [[ -z "$ts" ]] && continue
+
+            # Convert ISO 8601 to Unix timestamp
+            # macOS date syntax - TZ=UTC ensures the Z suffix is honored
+            if [[ "$(uname)" == "Darwin" ]]; then
+                reminder_time=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null)
+            else
+                # Linux date syntax
+                reminder_time=$(TZ=UTC date -d "$ts" +%s 2>/dev/null)
+            fi
+            [[ -z "$reminder_time" ]] && continue
+
+            # Check if due (past or now)
+            if [[ "$reminder_time" -le "$now" ]]; then
+                ((count++))
+            fi
+        done < <(grep -E '^\* \[ \] #reminder' "$file" 2>/dev/null)
+    done
+done
+
+# Output for tmux
+if [[ "$count" -gt 0 ]]; then
+    if [[ "$count" -eq 1 ]]; then
+        echo "#[fg=#131a24,bg=#f7768e,bold] $count reminder #[fg=#f7768e,bg=#131a24]"
+    else
+        echo "#[fg=#131a24,bg=#f7768e,bold] $count reminders #[fg=#f7768e,bg=#131a24]"
+    fi
+fi


### PR DESCRIPTION
  - Added :ReminderTmuxSetup to the commands list
  - Added new *nvim-reminders-tmux* section with:
    - Quick setup instructions
    - Manual setup details
    - Advanced powerline styling example
    - Platform support note

  You can now run :help nvim-reminders-tmux to see the new documentation.